### PR TITLE
feat: show leaderboard before game starts

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -19,10 +19,10 @@
       <div id="points">0</div>
       <button id="next" style="display:none;">Next Song</button>
     </div>
-    <div id="leaderboard">
-      <h2>Leaderboard</h2>
-      <ul id="users"></ul>
-    </div>
+  </div>
+  <div id="leaderboard">
+    <h2>Leaderboard</h2>
+    <ul id="users"></ul>
   </div>
   <div id="gameOverModal" class="hidden">
     <div class="modal-content">

--- a/public/gameScript.js
+++ b/public/gameScript.js
@@ -11,7 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const gameOverModal = document.getElementById('gameOverModal');
   const winnerMessage = document.getElementById('winnerMessage');
   const playAgain = document.getElementById('playAgain');
-  const usersUl = document.getElementById('users');
+  const leaderboard = document.getElementById('leaderboard');
+  const usersUl = leaderboard.querySelector('#users');
 
   const socket = io();
 


### PR DESCRIPTION
## Summary
- Move leaderboard out of hidden game area so it's visible with the start button
- Update client script to reference relocated leaderboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a87263eb188325bb54629d00aad003